### PR TITLE
Ajoute une page « À propos » (privée) et réécrit le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,102 @@
-# Astro Starter Kit: Blog
+# Les Héritiers de Dumnacus — Site web
 
-```sh
-npm create astro@latest -- --template blog
-```
+Site officiel de l'association **Les Héritiers de Dumnacus**, club de jeux de rôle sur table basé à Angers.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/blog)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/blog/devcontainer.json)
+## Objectif du projet
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+Ce dépôt contient le site public de l'association :
 
-![blog](https://github.com/withastro/astro/assets/2244813/ff10799f-a816-4703-b967-c78997e8323d)
+- présentation du club ;
+- informations pratiques pour rejoindre les tables ;
+- pages éditoriales autour des jeux de rôle ;
+- flux RSS et métadonnées SEO.
 
-Features:
+## Stack technique
 
-- ✅ Minimal styling (make it your own!)
-- ✅ 100/100 Lighthouse performance
-- ✅ SEO-friendly with canonical URLs and OpenGraph data
-- ✅ Sitemap support
-- ✅ RSS Feed support
-- ✅ Markdown & MDX support
+- [Astro 5](https://astro.build/) (SSG)
+- [Tailwind CSS](https://tailwindcss.com/)
+- `@astrojs/cloudflare` pour le build/déploiement Cloudflare
+- `@astrojs/sitemap` et `@astrojs/rss` pour le SEO et la syndication
 
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
+## Structure utile du projet
 
 ```text
-├── public/
+.
+├── public/               # assets statiques (images, polices, etc.)
 ├── src/
-│   ├── components/
-│   ├── content/
-│   ├── layouts/
-│   └── pages/
+│   ├── components/       # composants Astro réutilisables
+│   ├── layouts/          # layouts de pages/articles
+│   ├── pages/            # routes Astro
+│   ├── styles/           # styles globaux
+│   └── content.config.ts # config des collections de contenu
+├── docs/                 # documentation interne (audit, notes)
 ├── astro.config.mjs
-├── README.md
-├── package.json
-└── tsconfig.json
+├── wrangler.jsonc
+└── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Scripts npm
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+Commandes principales :
 
-The `src/content/` directory contains "collections" of related Markdown and MDX documents. Use `getCollection()` to retrieve posts from `src/content/blog/`, and type-check your frontmatter using an optional schema. See [Astro's Content Collections docs](https://docs.astro.build/en/guides/content-collections/) to learn more.
+- `npm run dev` : lance le serveur local sur `localhost:4321`
+- `npm run build` : build de production Astro (`dist/`)
+- `npm run preview` : prévisualisation locale du build
+- `npm run astro -- check` : vérifications Astro (types/routes/contenu)
 
-Any static assets, like images, can be placed in the `public/` directory.
+## Développement local
 
-## 🧞 Commands
+1. Installer les dépendances :
+   ```bash
+   npm install
+   ```
+2. Lancer le serveur de dev :
+   ```bash
+   npm run dev
+   ```
+3. Ouvrir : `http://localhost:4321`
 
-All commands are run from the root of the project, from a terminal:
+## Déploiement Cloudflare
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+Le projet est configuré pour un build Astro compatible Cloudflare via `@astrojs/cloudflare`.
 
-## 👀 Want to learn more?
+### Option A — Cloudflare Pages (recommandé)
 
-Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+- Build command : `npm run build`
+- Build output directory : `dist`
+- Configuration déjà alignée avec `wrangler.jsonc` (`pages_build_output_dir: "./dist"`).
 
-## Credit
+### Option B — Wrangler (CI/CD scriptée)
 
-This theme is based off of the lovely [Bear Blog](https://github.com/HermanMartinus/bearblog/).
+Exemple de publication Pages :
+
+```bash
+npx wrangler pages deploy dist --project-name heritiers-dumnacus
+```
+
+> Prérequis : variable `CLOUDFLARE_API_TOKEN` et authentification Wrangler configurée.
+
+## Conventions de travail
+
+- Garder une cohérence visuelle avec le thème actuel (bois/parchemin/typographies).
+- Préférer les composants existants dans `src/components/` avant d'en créer de nouveaux.
+- Vérifier les liens canoniques/SEO lors de l'ajout d'une nouvelle page.
+- Éviter les assets orphelins dans `public/`.
+
+## Checklist de release
+
+Avant mise en production :
+
+1. `npm run build`
+2. `npm run astro -- check`
+3. Vérifier manuellement les pages clés :
+   - `/`
+   - `/nousrejoindre`
+   - `/jeuxderole`
+4. Vérifier sitemap et flux RSS générés.
+5. Déployer sur Cloudflare Pages.
+
+## Notes
+
+- La page `/about` existe mais reste volontairement non accessible publiquement tant que la variable
+  d'environnement `PUBLIC_ENABLE_ABOUT_PAGE` n'est pas définie à `true`.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,62 +1,97 @@
 ---
-import Layout from '../layouts/BlogPost.astro';
+import BaseHead from "../components/BaseHead.astro";
+import Body from "../components/navigation/Body.astro";
+
+const isAboutPageEnabled = import.meta.env.PUBLIC_ENABLE_ABOUT_PAGE === "true";
+
+if (!isAboutPageEnabled) {
+  return Astro.redirect("/404");
+}
 ---
 
-<Layout
-	title="About Me"
-	description="Lorem ipsum dolor sit amet"
-	pubDate={new Date('August 08 2021')}
-	heroImage="/blog-placeholder-about.jpg"
->
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-		labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo
-		viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam
-		adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus
-		et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus
-		vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque
-		sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.
-	</p>
+<html lang="fr">
+  <head>
+    <BaseHead
+      title="À propos | Les Héritiers de Dumnacus"
+      description="Présentation de l'association Les Héritiers de Dumnacus, club de jeux de rôle à Angers."
+      canonicalURL="https://www.heritiersdedumnacus.fr/about/"
+    />
+  </head>
 
-	<p>
-		Morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non
-		tellus. Habitasse platea dictumst quisque sagittis purus sit amet. Tellus molestie nunc non
-		blandit massa. Cursus vitae congue mauris rhoncus. Accumsan tortor posuere ac ut. Fringilla urna
-		porttitor rhoncus dolor. Elit ullamcorper dignissim cras tincidunt lobortis. In cursus turpis
-		massa tincidunt dui ut ornare lectus. Integer feugiat scelerisque varius morbi enim nunc.
-		Bibendum neque egestas congue quisque egestas diam. Cras ornare arcu dui vivamus arcu felis
-		bibendum. Dignissim suspendisse in est ante in nibh mauris. Sed tempus urna et pharetra pharetra
-		massa massa ultricies mi.
-	</p>
+  <Body>
+    <section class="mx-auto mt-8 w-11/12 max-w-6xl">
+      <h1
+        class="margin rounded-lg border-[3px] p-6 text-center font-richard text-6xl drop-shadow-lg"
+        style="background-color: rgba(117, 186, 3, 0.7);"
+      >
+        À propos
+      </h1>
 
-	<p>
-		Mollis nunc sed id semper risus in. Convallis a cras semper auctor neque. Diam sit amet nisl
-		suscipit. Lacus viverra vitae congue eu consequat ac felis donec. Egestas integer eget aliquet
-		nibh praesent tristique magna sit amet. Eget magna fermentum iaculis eu non diam. In vitae
-		turpis massa sed elementum. Tristique et egestas quis ipsum suspendisse ultrices. Eget lorem
-		dolor sed viverra ipsum. Vel turpis nunc eget lorem dolor sed viverra. Posuere ac ut consequat
-		semper viverra nam. Laoreet suspendisse interdum consectetur libero id faucibus. Diam phasellus
-		vestibulum lorem sed risus ultricies tristique. Rhoncus dolor purus non enim praesent elementum
-		facilisis. Ultrices tincidunt arcu non sodales neque. Tempus egestas sed sed risus pretium quam
-		vulputate. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Fringilla
-		urna porttitor rhoncus dolor purus non. Amet dictum sit amet justo donec enim.
-	</p>
+      <div class="about-grid mt-8">
+        <article class="parchment-highlight p-8">
+          <h2 class="paragraph-header">Qui sommes-nous ?</h2>
+          <p>
+            Les Héritiers de Dumnacus est une association angevine (loi 1901) dédiée au jeu de rôle sur table,
+            active dans le quartier des Justices à Angers. L'association accueille aussi bien les personnes qui
+            découvrent le JdR que les joueuses et joueurs expérimentés.
+          </p>
+          <p>
+            Le nom « Dumnacus » fait référence à un chef gaulois de la région andécave, un clin d'œil à l'histoire
+            locale et à l'ancrage territorial de l'association.
+          </p>
+        </article>
 
-	<p>
-		Mattis ullamcorper velit sed ullamcorper morbi tincidunt. Tortor posuere ac ut consequat semper
-		viverra. Tellus mauris a diam maecenas sed enim ut sem viverra. Venenatis urna cursus eget nunc
-		scelerisque viverra mauris in. Arcu ac tortor dignissim convallis aenean et tortor at. Curabitur
-		gravida arcu ac tortor dignissim convallis aenean et tortor. Egestas tellus rutrum tellus
-		pellentesque eu. Fusce ut placerat orci nulla pellentesque dignissim enim sit amet. Ut enim
-		blandit volutpat maecenas volutpat blandit aliquam etiam. Id donec ultrices tincidunt arcu. Id
-		cursus metus aliquam eleifend mi.
-	</p>
+        <article class="parchment-highlight p-8">
+          <h2 class="paragraph-header">Nos activités</h2>
+          <p>
+            L'association organise des sessions chaque week-end, avec des parties le samedi et le dimanche,
+            généralement proposées par les meneurs et meneuses sur le forum.
+          </p>
+          <p>
+            Les jeux pratiqués couvrent plusieurs univers (fantasy, horreur, science-fiction, post-apo…), avec une
+            attention particulière portée à l'accueil des nouveaux membres et au partage des tables.
+          </p>
+        </article>
+      </div>
 
-	<p>
-		Tempus quam pellentesque nec nam aliquam sem. Risus at ultrices mi tempus imperdiet. Id porta
-		nibh venenatis cras sed felis eget velit. Ipsum a arcu cursus vitae. Facilisis magna etiam
-		tempor orci eu lobortis elementum. Tincidunt dui ut ornare lectus sit. Quisque non tellus orci
-		ac. Blandit libero volutpat sed cras. Nec tincidunt praesent semper feugiat nibh sed pulvinar
-		proin gravida. Egestas integer eget aliquet nibh praesent tristique magna.
-	</p>
-</Layout>
+      <div class="about-grid mt-8">
+        <article class="parchment-highlight p-8">
+          <h2 class="paragraph-header">Informations pratiques</h2>
+          <ul class="ml-6 list-disc">
+            <li>Adresse actuelle annoncée : Résidence Arceau, 12 rue Boisramé, 49000 Angers.</li>
+            <li>Prise de contact : forum, Discord et e-mail associatif.</li>
+            <li>Premières séances possibles en découverte avant adhésion annuelle.</li>
+          </ul>
+          <p>
+            Pour suivre les parties et proposer une table, le forum reste le point de référence de l'organisation.
+          </p>
+        </article>
+
+        <article class="parchment-highlight p-8">
+          <h2 class="paragraph-header">Sources publiques utilisées</h2>
+          <p>
+            Cette page compile des informations publiques déjà diffusées par l'association sur ses canaux en ligne
+            (site, forum, communauté Discord) et des éléments historiques généraux sur Dumnacus.
+          </p>
+          <p>
+            Le contenu sera enrichi avec des validations de l'équipe avant publication officielle.
+          </p>
+        </article>
+      </div>
+    </section>
+  </Body>
+</html>
+
+<style>
+  .about-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2rem;
+  }
+
+  @media (max-width: 900px) {
+    .about-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>


### PR DESCRIPTION
### Motivation
- Remplacer le contenu lorem ipsum du template par une vraie page « À propos » pertinente pour l’association. 
- Garder la page invisible en production tant qu’elle n’est pas validée par l’équipe. 
- Adapter la documentation du dépôt pour refléter le projet réel (stack, commandes, déploiement, checklist). 

### Description
- Remplacement complet de `src/pages/about.astro` par une page structurée (présentation, activités, infos pratiques, sources) utilisant `BaseHead`, `Body` et les classes visuelles existantes (`parchment-highlight`, `paragraph-header`) pour rester cohérent avec le site. 
- Ajout d’un garde-fou pour rendre la page non accessible par défaut en vérifiant `import.meta.env.PUBLIC_ENABLE_ABOUT_PAGE === "true"` et en redirigeant vers `/404` si non activée. 
- Réécriture du `README.md` du starter pour documenter le projet réel (objectif, stack, structure, scripts, déploiement Cloudflare, conventions et checklist de release). 

### Testing
- Exécution de `npm run build` — build terminé avec succès (le message de build note les warnings existants sur les collections manquantes mais aucun échec). 
- Exécution de `npm run astro -- check` — contrôle terminé sans erreurs bloquantes (hints/warnings existants sur imports/collections non résolus restent signalés). 
- Démarrage en preview avec `PUBLIC_ENABLE_ABOUT_PAGE=true npm run dev` et capture de la page `/about/` via Playwright — rendu visuel vérifié et capture produite avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c2723fdc8321a604416b439cc425)